### PR TITLE
S110272: Client metrics should record all component ready events inst…

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -12,7 +12,6 @@ module.exports = function(grunt) {
   grunt.loadNpmTasks('grunt-text-replace');
   grunt.loadNpmTasks('grunt-open');
   grunt.loadNpmTasks('grunt-release');
-  grunt.loadTasks('grunt/tasks');
   grunt.registerTask('default', ['ci']);
   grunt.registerTask('ci', 'Runs everything: cleans and runs the tests', ['clean', 'test:setup', 'mocha']);
   grunt.registerTask('test', 'Does the test setup and runs the tests in the default browser. Use --browser=<other> to run in a different browser, and --port=<port> for a different port.', ['test:setup', 'mocha']);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rally-clientmetrics",
-  "version": "4.0.0",
+  "version": "4.1.0",
   "description": "Metrics aggregation for Rally Software",
   "main": "builds/rallymetrics.js",
   "scripts": {


### PR DESCRIPTION
…ead of one per component per session

This commit fixes two problems related to component ready events.

Problem 1: Component ready events are not sent if they have already been sent in the existing session. Therefore, if another action occurs in the same session that triggers the same component ready event, it will not be sent.
Fix 1: All component ready events should be sent.

Problem 2: The component ready time is recorded as (time component ready event is created) - (session start time). However, it is assumed that actions are the events that lead to component ready events, not sessions. Therefore, component ready times should be (time component ready event is created) - (action start time).

As an example of the problem, consider the following sequence of events:

1. User navigates to a page a time T
2. System starts session at time T
3. User gets a cup of coffee
4. User interacts with the application at time T+coffeeTime
5. System records action at time T+coffeeTime
6. System instantiates a component
7. System records component ready at time T+coffeeTime+C

With out this change: the component ready time will be recorded as (T+coffeeTime+C) - (T) = coffeeTime+C. The component ready time includes the coffeeTime!

Fix 2: Component ready start time should equal action start time, not session start time.

With this change: the component ready time will be recorded as (T+coffeeTime+C) - (T+coffeeTime) = C. This accurately reflects the component ready time.