### PR TITLE
Expose getCurrentTraceId function

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,19 +36,19 @@
     "doc"
   ],
   "devDependencies": {
-    "babel-core": "^6.3.17",
-    "babel-eslint": "^4.1.6",
-    "babel-loader": "^6.2.0",
-    "babel-plugin-transform-object-assign": "^6.3.13",
-    "babel-polyfill": "^6.3.14",
-    "babel-preset-es2015": "^6.3.13",
-    "babel-preset-stage-1": "^6.3.13",
+    "babel-core": "6.8.0",
+    "babel-eslint": "6.0.4",
+    "babel-loader": "6.2.4",
+    "babel-plugin-transform-object-assign": "6.8.0",
+    "babel-polyfill": "6.8.0",
+    "babel-preset-es2015": "6.6.0",
+    "babel-preset-stage-1": "6.5.0",
     "chai": "~1.9.0",
     "eslint": "^1.10.3",
-    "eslint-config-rally": "^1.5.0",
-    "eslint-plugin-jasmine": "^1.6.0",
-    "eslint-plugin-rally": "^0.4.0",
-    "eslint-plugin-react": "^3.11.3",
+    "eslint-config-rally": "2.3.0",
+    "eslint-plugin-jasmine": "1.8.1",
+    "eslint-plugin-rally": "1.1.0",
+    "eslint-plugin-react": "5.1.1",
     "eslint-plugin-whitespace": "^0.1.3",
     "express": "~3.3.4",
     "grunt": "~0.4.2",
@@ -60,17 +60,18 @@
     "grunt-open": "~0.2.3",
     "grunt-release": "^0.13.0",
     "grunt-text-replace": "^0.4.0",
-    "mocha": "^2.3.4",
+    "mocha": "2.4.5",
     "node-static": "^0.7.6",
     "sinon": "~1.9.0",
-    "sinon-chai": "~2.5.0",
-    "webpack": "^1.12.9"
+    "sinon-chai": "2.8.0",
+    "uuid": "2.0.2",
+    "webpack": "1.13.0"
   },
   "dependencies": {
     "uuid": "^2.0.1",
     "when": "~2.7.0"
   },
   "publishConfig": {
-    "registry":"http://npm-publish.f4tech.com"
+    "registry": "http://npm-publish.f4tech.com"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rally-clientmetrics",
-  "version": "4.1.0",
+  "version": "4.2.0",
   "description": "Metrics aggregation for Rally Software",
   "main": "builds/rallymetrics.js",
   "scripts": {

--- a/src/__unit__/.eslintrc
+++ b/src/__unit__/.eslintrc
@@ -1,0 +1,5 @@
+{
+  "rules": {
+    "no-unused-expressions": 0
+  }
+}

--- a/src/__unit__/aggregator.spec.js
+++ b/src/__unit__/aggregator.spec.js
@@ -810,6 +810,29 @@ describe("Aggregator", () => {
       expect(sentEvents.length).to.equal(3);
     });
   });
+
+  describe('#getCurrentTraceId', () => {
+    it("should return null if no actions have been recorded", () => {
+      const aggregator = createAggregator();
+      expect(aggregator.getCurrentTraceId()).to.be.null;
+    });
+
+    it("should return the traceId of the most recently recorded action", () => {
+      const aggregator = createAggregator();
+      const firstTraceId = aggregator.recordAction({
+        component: {},
+        description: "an action"
+      });
+      expect(aggregator.getCurrentTraceId()).to.equal(firstTraceId);
+
+      const secondTraceId = aggregator.recordAction({
+        component: {},
+        description: "an action"
+      });
+      expect(aggregator.getCurrentTraceId()).to.equal(secondTraceId);
+    });
+  });
+
   describe("#getRallyRequestId", () => {
     it("should find the RallyRequestId on an object", () => {
       const response = {

--- a/src/__unit__/aggregator.spec.js
+++ b/src/__unit__/aggregator.spec.js
@@ -195,14 +195,6 @@ describe("Aggregator", () => {
     });
   });
   describe('#startSession', () => {
-    it("should start a new session", () => {
-      const aggregator = createAggregator();
-      const status = 'Navigation';
-      const defaultParams = {
-        foo: 'bar'
-      };
-      return startSession(aggregator, status, defaultParams);
-    });
     it("should flush the sender", () => {
       const aggregator = createAggregator();
       startSession(aggregator);
@@ -473,7 +465,6 @@ describe("Aggregator", () => {
   describe('finding traceIDs', () => {
     it("should find the correct traceId", () => {
       const aggregator = createAggregator();
-      const handler = aggregator.handlers[0];
       const parentPanel = new Panel();
       const childPanel = parentPanel.add({
         xtype: "panel"
@@ -488,7 +479,6 @@ describe("Aggregator", () => {
     });
     it("should not parent to an event that has completed", () => {
       const aggregator = createAggregator();
-      const handler = aggregator.handlers[0];
       const parentPanel = new Panel();
       const childPanel1 = parentPanel.add({
         xtype: "panel"
@@ -540,7 +530,7 @@ describe("Aggregator", () => {
     });
     it("should use the passed-in startTime", () => {
       const aggregator = createAggregator();
-      const traceId = aggregator.recordAction({
+      aggregator.recordAction({
         component: {},
         description: "an action",
         startTime: 100
@@ -674,7 +664,7 @@ describe("Aggregator", () => {
         errorMessages.push(recordError(aggregator));
       }
       expect(sentEvents.length).to.equal(4);
-      const ref = sentEvents.slice(1).forEach((errorEvent, i) => {
+      sentEvents.slice(1).forEach((errorEvent, i) => {
         expect(errorEvent.error).to.equal("an error");
         expect(errorEvent.stack).to.equal(limitStack(errorMessages[i].stack, 10));
       });

--- a/src/__unit__/corsBatchSender.spec.js
+++ b/src/__unit__/corsBatchSender.spec.js
@@ -17,11 +17,6 @@ const getData = (count) => {
   return results;
 };
 
-const getSentData = (callIndex = 0) => {
-  const sentJson = mockXhr.send.args[callIndex][0];
-  return JSON.parse(sentJson);
-};
-
 describe("CorsBatchSender", () => {
 
   beforeEach(() => {
@@ -88,7 +83,7 @@ describe("CorsBatchSender", () => {
         }
         done();
       };
-      const results = data.map(datum => sender.send(datum));
+      data.map(datum => sender.send(datum));
     });
 
     it("should not send a batch if the number of events is less than the minium", () => {

--- a/src/aggregator.js
+++ b/src/aggregator.js
@@ -137,6 +137,7 @@ class Aggregator {
     this._pendingEvents = [];
     this._browserTabId = getUniqueId();
     this._startingTime = Date.now();
+    this._currentTraceId = null;
 
     // keep track of how many errors we have reported on, so we
     // can stop after a while and not flood the beacon
@@ -527,6 +528,10 @@ class Aggregator {
 
   getSessionStartTime() {
     return this._sessionStartTime;
+  }
+
+  getCurrentTraceId() {
+    return this._currentTraceId;
   }
 
   /**


### PR DESCRIPTION
This can be used by consumers if they want to make sure that they
only end a span (or component ready) if the current trace id matches
the id of the trace that was current when the span was started.