### PR TITLE
Add sdk-friendly output file that omits source maps

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,13 +1,13 @@
 {
   "name": "rally-clientmetrics",
-  "version": "4.2.0",
+  "version": "4.2.1",
   "description": "Metrics aggregation for Rally Software",
   "main": "builds/rallymetrics.js",
   "scripts": {
     "lint": "eslint src",
     "docs": "grunt jsdoc",
     "test": "npm run webpack:test && grunt test",
-    "webpack": "webpack --progress --config webpack.dev.config.js && webpack --progress --config webpack.prod.config.js",
+    "webpack": "webpack --progress --config webpack.dev.config.js && webpack --progress --config webpack.prod.config.js && webpack --progress --config webpack.sdk.config.js",
     "webpack:test": "webpack --debug --progress --config webpack.test.config.js",
     "webpack:analyze": "webpack --debug --progress --config webpack.dev.config.js --json > webpack-stats.json",
     "prepublish": "npm run webpack && npm run docs"

--- a/webpack.sdk.config.js
+++ b/webpack.sdk.config.js
@@ -1,0 +1,33 @@
+var path = require('path');
+var webpack = require('webpack');
+
+module.exports = {
+  context: __dirname,
+  entry: "./src/main.js",
+  output: {
+    path: path.join(__dirname, "/builds"),
+    filename: "rallymetrics.sdk.js",
+    library: "RallyMetrics",
+    libraryTarget: 'umd'
+  },
+
+  debug: true,
+
+  stats: {
+    colors: true,
+    reasons: true
+  },
+
+  resolve: {
+    modulesDirectories: ["node_modules"],
+    extensions: ["", ".webpack.js", ".web.js", ".js"]
+  },
+
+  module: {
+    loaders: [
+      {
+        test: /\.js$/, exclude: /node_modules/, loader: 'babel'
+      }
+    ]
+  }
+};


### PR DESCRIPTION
This is for DE27307: https://rally1.rallydev.com/#/23712112623/detail/defect/55991329557

Basically, we need to have a rallymetrics file that does not have a source map in it because it screws up the chrome debugger when trying to debug sdk-debug.js