### PR TITLE
Added callback function to be passed in along with events

### DIFF
--- a/src/aggregator.js
+++ b/src/aggregator.js
@@ -511,6 +511,12 @@ class Aggregator {
     this.sender.flush();
   }
 
+  setBatchCallback(xhrCallback) {
+    if (xhrCallback) {
+      this.sender._xhrCallback = xhrCallback;
+    }
+  }
+
   getComponentType(cmp) {
     return this._getFromHandlers(cmp.singleton || cmp, 'getComponentType');
   }

--- a/src/aggregator.js
+++ b/src/aggregator.js
@@ -511,9 +511,15 @@ class Aggregator {
     this.sender.flush();
   }
 
-  setBatchCallback(xhrCallback) {
+  addBatchCallback(key, xhrCallback) {
     if (xhrCallback) {
-      this.sender._xhrCallback = xhrCallback;
+      this.sender._xhrCallbacks[key] = xhrCallback;
+    }
+  }
+
+  removeBatchCallback(key) {
+    if (this.sender._xhrCallbacks[key]) {
+      delete this.sender._xhrCallbacks[key];
     }
   }
 

--- a/src/corsBatchSender.js
+++ b/src/corsBatchSender.js
@@ -53,6 +53,7 @@ class CorsBatchSender {
       this._disableClientMetrics();
     }
     this._eventQueue = [];
+    this._xhrCallbacks = {};
   }
 
   send(event) {
@@ -126,13 +127,13 @@ class CorsBatchSender {
       if (xhr) {
         xhr.onreadystatechange = () => {
           if (xhr.readyState === XMLHttpRequest.DONE) {
-            if (this._xhrCallback) {
-              const eIds = events.map(function(event) {
-                return event.eId;
-              });
+            const eIds = events.map(function(event) {
+              return event.eId;
+            });
 
-              this._xhrCallback(xhr.status, eIds);
-            }
+            Object.values(this._xhrCallbacks).forEach(function(xhrCallback) {
+              xhrCallback(xhr.status, eIds);
+            });
           }
         };
 

--- a/src/corsBatchSender.js
+++ b/src/corsBatchSender.js
@@ -131,9 +131,9 @@ class CorsBatchSender {
               return event.eId;
             });
 
-            Object.values(this._xhrCallbacks).forEach(function(xhrCallback) {
-              xhrCallback(xhr.status, eIds);
-            });
+            for (let key in this._xhrCallbacks) {
+              this._xhrCallbacks[key](xhr.status, eIds);
+            }
           }
         };
 

--- a/src/corsBatchSender.js
+++ b/src/corsBatchSender.js
@@ -122,7 +122,20 @@ class CorsBatchSender {
 
     try {
       const xhr = createCorsXhr('POST', this.beaconUrl);
+
       if (xhr) {
+        xhr.onreadystatechange = () => {
+          if (xhr.readyState === XMLHttpRequest.DONE) {
+            if (this._xhrCallback) {
+              const eIds = events.map(function(event) {
+                return event.eId;
+              });
+
+              this._xhrCallback(xhr.status, eIds);
+            }
+          }
+        };
+
         xhr.onerror = this._disableClientMetrics.bind(this);
         setTimeout(() => xhr.send(JSON.stringify(data)), 0);
       } else {


### PR DESCRIPTION
This change allows Churro functions to receive notification when a ClientMetrics event's request is completed. This is desirable because it allows TACo tests to wait until ClientMetrics spans have been posted before forcing the test to shut down.

We now pass a callback function through the startSpan function which then gets mapped to the resulting event by its event ID within the sender. The sender then searches each batch of events for mapped callback functions and calls them after the XMLHTTPRequest has a state of DONE. The XMLHTTPRequest status is passed in as an argument to each callback.