### PR TITLE
Filter react lifecycle methods from stack trace reporting

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rally-clientmetrics",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "description": "Metrics aggregation for Rally Software",
   "main": "builds/rallymetrics.js",
   "scripts": {

--- a/src/__unit__/aggregator.spec.js
+++ b/src/__unit__/aggregator.spec.js
@@ -195,7 +195,7 @@ describe("Aggregator", () => {
       expect(aggregator.handlers[0]).to.equal(newHandler);
     });
   });
-  
+
   describe('#startSession', () => {
     it("should flush the sender", () => {
       const aggregator = createAggregator();
@@ -654,6 +654,16 @@ describe("Aggregator", () => {
       const errorEvent = findErrorEvent();
 
       expect(errorEvent.stack).to.equal(limitStack(errorMessage.stack, 2));
+    });
+
+    it("filters stacks that match ignoreStackMatcher", () => {
+      const ignoreStackMatcher = /recordError/;
+      const aggregator = createAggregatorAndRecordAction({ ignoreStackMatcher });
+
+      recordError(aggregator);
+      const errorEvent = findErrorEvent();
+
+      expect(ignoreStackMatcher.test(errorEvent.stack)).to.equal(false);
     });
 
     it("does not create an error event if the error limit has been reached", () => {


### PR DESCRIPTION
Filter methods matching regex from stack trace reporting.

Used so more informative stack lines can fit within `stackLimit`, for example ignoring react functions from errors triggered in churro.